### PR TITLE
feat: Make MCP connector runner-agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,15 @@ A high-performance Model Context Protocol (MCP) server that provides seamless in
 
 ### 📦 Instalación Remota (Recomendado)
 
-#### Opción A: NPM Global
+Nuestros scripts de instalación ahora detectan automáticamente el mejor ejecutor de paquetes (`uvx`, `npx`, `npm`) disponible en tu sistema para una experiencia más fluida y un rendimiento óptimo.
+
+Puedes anular el ejecutor detectado configurando la variable de entorno `RUNNER`. Por ejemplo: `RUNNER=npm ./install-remote.sh`.
+
+#### Opción A: Ejecución Remota con Runner Dinámico
 ```bash
 # Instalación automática
 curl -fsSL https://raw.githubusercontent.com/carlosjperez/n8n-mcp-connector/main/install-remote.sh | bash
-# Selecciona opción 1 (NPM Global)
+# Selecciona la opción 1
 ```
 
 #### Opción B: MCP.so
@@ -86,7 +90,9 @@ N8N_PASSWORD=your_password
 
 ### Claude Desktop Integration
 
-#### 📦 Configuración NPM Global (Sin instalación local)
+**Nota:** Los scripts de instalación se encargan de esto automáticamente. La siguiente configuración es un ejemplo. El campo `command` será rellenado por el script de instalación con el ejecutor de paquetes detectado (`uvx`, `npx`, o `npm`).
+
+#### 📦 Configuración de Ejecución Remota (Ejemplo)
 
 ```json
 {

--- a/REMOTE-USAGE.md
+++ b/REMOTE-USAGE.md
@@ -8,7 +8,9 @@
 
 ## 🔧 Configuración Inmediata para Claude Desktop
 
-### Opción 1: NPM Global (Sin instalación local)
+### Opción 1: Ejecución Remota (Sin instalación local)
+
+**Nota:** El sistema detectará automáticamente el mejor ejecutor de paquetes disponible (`uvx`, `npx`, `npm`). El comando `npx` se usa aquí como ejemplo.
 
 ```json
 {
@@ -136,21 +138,21 @@ Una vez configurado, tendrás acceso a:
 
 ## 🔄 Actualizaciones
 
-El paquete se actualiza automáticamente cuando uses `@latest`. Para forzar una actualización:
+El paquete se actualiza automáticamente cuando uses `@latest`. Para forzar una actualización, puedes limpiar la caché de tu ejecutor de paquetes.
 
 ```bash
-# Limpiar caché de npx
+# Ejemplo para limpiar caché de npx
 npx clear-npx-cache
 
-# O usar versión específica
-npx n8n-mcp-connector@1.0.0
+# Ejemplo para usar una versión específica con un runner determinado
+RUNNER=npx n8n-mcp-connector@1.0.0
 ```
 
 ## 🆘 Solución de Problemas
 
 ### Error: "Command not found"
-- Asegúrate de tener Node.js instalado
-- Verifica que npx esté disponible: `npx --version`
+- Asegúrate de tener Node.js instalado.
+- Verifica que un ejecutor de paquetes esté disponible en tu PATH: `uvx --version`, `npx --version`, o `npm --version`.
 
 ### Error: "N8N authentication required"
 - Verifica que `N8N_BASE_URL` sea correcta

--- a/install-cursor.sh
+++ b/install-cursor.sh
@@ -5,6 +5,11 @@
 
 set -e
 
+# Importar y usar el detector de runner
+source "$(dirname "$0")/scripts/detect-runner.sh"
+RUNNER=$(detect_runner)
+echo "🏃 Runner detectado: $RUNNER"
+
 echo "🎯 N8N MCP Connector - Instalación Universal para Agentes IA"
 echo "============================================================"
 echo ""
@@ -59,7 +64,7 @@ setup_cursor() {
     
     case $install_choice in
         1)
-            generate_base_config "npx" '"n8n-mcp-connector"' > "$config_file"
+            generate_base_config "$RUNNER" '"n8n-mcp-connector"' > "$config_file"
             ;;
         2)
             generate_base_config "mcp" '"install", "n8n-workflows/carlosjperez"' > "$config_file"
@@ -92,7 +97,7 @@ setup_continue() {
     {
       "name": "n8n-workflows",
       "params": {
-        "serverCommand": "npx n8n-mcp-connector",
+        "serverCommand": "$RUNNER n8n-mcp-connector",
         "env": {
           "N8N_BASE_URL": "https://tu-instancia-n8n.com",
           "N8N_API_KEY": "tu_api_key_aqui"
@@ -116,7 +121,7 @@ setup_codeium() {
     
     case $install_choice in
         1)
-            generate_base_config "npx" '"n8n-mcp-connector"' > "$config_file"
+            generate_base_config "$RUNNER" '"n8n-mcp-connector"' > "$config_file"
             ;;
         2)
             generate_base_config "mcp" '"install", "n8n-workflows/carlosjperez"' > "$config_file"
@@ -147,7 +152,7 @@ setup_claude() {
     
     case $install_choice in
         1)
-            generate_base_config "npx" '"n8n-mcp-connector"' > "$config_file"
+            generate_base_config "$RUNNER" '"n8n-mcp-connector"' > "$config_file"
             ;;
         2)
             generate_base_config "mcp" '"install", "n8n-workflows/carlosjperez"' > "$config_file"
@@ -172,7 +177,7 @@ setup_manual() {
     case $install_choice in
         1)
             echo "NPM Global:"
-            generate_base_config "npx" '"n8n-mcp-connector"'
+            generate_base_config "$RUNNER" '"n8n-mcp-connector"'
             ;;
         2)
             echo "MCP.so:"

--- a/install-remote.sh
+++ b/install-remote.sh
@@ -5,6 +5,11 @@
 
 set -e
 
+# Importar y usar el detector de runner
+source "$(dirname "$0")/scripts/detect-runner.sh"
+RUNNER=$(detect_runner)
+echo "🏃 Runner detectado: $RUNNER"
+
 echo "🚀 N8N MCP Connector - Instalación Remota"
 echo "==========================================="
 echo ""
@@ -33,11 +38,11 @@ fi
 case $choice in
     1)
         echo "📦 Configurando para NPM Global..."
-        cat > "$CLAUDE_CONFIG_FILE" << 'EOF'
+        cat > "$CLAUDE_CONFIG_FILE" << EOF
 {
   "mcpServers": {
     "n8n-workflows": {
-      "command": "npx",
+      "command": "$RUNNER",
       "args": ["n8n-mcp-connector"],
       "env": {
         "N8N_BASE_URL": "https://tu-instancia-n8n.com",

--- a/install-universal.sh
+++ b/install-universal.sh
@@ -5,6 +5,11 @@
 
 set -e
 
+# Importar y usar el detector de runner
+source "$(dirname "$0")/scripts/detect-runner.sh"
+RUNNER=$(detect_runner)
+echo "🏃 Runner detectado: $RUNNER"
+
 echo "🚀 N8N MCP Connector - Instalación Universal"
 echo "============================================"
 echo ""
@@ -50,11 +55,11 @@ configure_agent() {
             local config_file="$config_dir/config.json"
             mkdir -p "$config_dir"
             
-            cat > "$config_file" << 'EOF'
+            cat > "$config_file" << EOF
 {
   "mcpServers": {
     "n8n-workflows": {
-      "command": "npx",
+      "command": "$RUNNER",
       "args": ["n8n-mcp-connector@latest"],
       "env": {
         "N8N_BASE_URL": "https://tu-instancia-n8n.com",
@@ -80,11 +85,11 @@ EOF
                 cp "$config_file" "$config_file.backup.$(date +%Y%m%d_%H%M%S)"
             fi
             
-            cat > "$config_file" << 'EOF'
+            cat > "$config_file" << EOF
 {
   "mcpServers": {
     "n8n-workflows": {
-      "command": "npx",
+      "command": "$RUNNER",
       "args": ["n8n-mcp-connector@latest"],
       "env": {
         "N8N_BASE_URL": "https://tu-instancia-n8n.com",
@@ -108,7 +113,7 @@ EOF
                 cp "$config_file" "$config_file.backup.$(date +%Y%m%d_%H%M%S)"
             fi
             
-            cat > "$config_file" << 'EOF'
+            cat > "$config_file" << EOF
 {
   "models": [],
   "customCommands": [],
@@ -116,7 +121,7 @@ EOF
     {
       "name": "n8n-workflows",
       "params": {
-        "serverCommand": "npx n8n-mcp-connector",
+        "serverCommand": "$RUNNER n8n-mcp-connector",
         "env": {
           "N8N_BASE_URL": "https://tu-instancia-n8n.com",
           "N8N_API_KEY": "tu_api_key_aqui"
@@ -128,7 +133,7 @@ EOF
     "enableMCP": true,
     "mcpServers": {
       "n8n-workflows": {
-        "command": "npx",
+        "command": "$RUNNER",
         "args": ["n8n-mcp-connector"],
         "env": {
           "N8N_BASE_URL": "https://tu-instancia-n8n.com",
@@ -148,11 +153,11 @@ EOF
             local config_file="$config_dir/mcp-config.json"
             mkdir -p "$config_dir"
             
-            cat > "$config_file" << 'EOF'
+            cat > "$config_file" << EOF
 {
   "mcpServers": {
     "n8n-workflows": {
-      "command": "npx",
+      "command": "$RUNNER",
       "args": ["n8n-mcp-connector@latest"],
       "env": {
         "N8N_BASE_URL": "https://tu-instancia-n8n.com",

--- a/scripts/detect-runner.sh
+++ b/scripts/detect-runner.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Función para detectar el mejor ejecutor de paquetes disponible.
+# El orden de prioridad es: uvx > npx > npm.
+# Si no se encuentra ninguno, devuelve "npx" como fallback seguro.
+detect_runner() {
+  if command -v uvx &> /dev/null; then
+    echo "uvx"
+  elif command -v npx &> /dev/null; then
+    echo "npx"
+  elif command -v npm &> /dev/null; then
+    echo "npm"
+  else
+    echo "npx" # Failsafe
+  fi
+}

--- a/verify-github-mcp.sh
+++ b/verify-github-mcp.sh
@@ -68,9 +68,12 @@ echo "==================== VERIFICACIÓN SISTEMA ===================="
 # Verify Zed installation
 run_test "Zed instalado" "command -v zed"
 
-# Verify Node.js and npx
+# Verify Node.js and a runner
+source "$(dirname "$0")/scripts/detect-runner.sh"
+RUNNER=$(detect_runner)
+echo "🏃 Runner detectado: $RUNNER"
 run_test "Node.js disponible" "command -v node"
-run_test "NPX disponible" "command -v npx"
+run_test "Runner ($RUNNER) disponible" "command -v $RUNNER"
 
 # Verify Docker availability
 if command -v docker &> /dev/null && docker info &> /dev/null; then
@@ -182,7 +185,7 @@ fi
 
 # Test mcp-remote package availability
 print_test "Disponibilidad de mcp-remote"
-if npx -y mcp-remote --help &> /dev/null 2>&1; then
+if $RUNNER -y mcp-remote --help &> /dev/null 2>&1; then
     print_success "mcp-remote responde correctamente"
     ((TESTS_PASSED++))
 else

--- a/verify-linear-mcp.sh
+++ b/verify-linear-mcp.sh
@@ -63,9 +63,12 @@ echo "==================== VERIFICACIÓN SISTEMA ===================="
 # Verify Zed installation
 run_test "Zed instalado" "command -v zed"
 
-# Verify Node.js and npx
+# Verify Node.js and a runner
+source "$(dirname "$0")/scripts/detect-runner.sh"
+RUNNER=$(detect_runner)
+echo "🏃 Runner detectado: $RUNNER"
 run_test "Node.js disponible" "command -v node"
-run_test "NPX disponible" "command -v npx"
+run_test "Runner ($RUNNER) disponible" "command -v $RUNNER"
 
 # Check Zed configuration directory
 run_test "Directorio de configuración Zed existe" "[ -d '$HOME/.config/zed' ]"
@@ -117,7 +120,7 @@ echo "==================== VERIFICACIÓN CONECTIVIDAD ===================="
 
 # Test mcp-remote package availability
 print_test "Disponibilidad de mcp-remote"
-if npx -y mcp-remote --help &> /dev/null; then
+if $RUNNER -y mcp-remote --help &> /dev/null; then
     print_success "mcp-remote responde correctamente"
     ((TESTS_PASSED++))
 else


### PR DESCRIPTION
Refactors the n8n MCP connector to be agnostic to the package runner.

This commit introduces a `detect_runner` utility script that dynamically detects the best available package runner in your environment, prioritizing `uvx`, then `npx`, and falling back to `npm`.

Key changes:
- All installation, verification, and utility scripts have been updated to use the detected runner via a `RUNNER` environment variable.
- `npx` is maintained as the default fallback to ensure full backwards compatibility.
- Documentation (`README.md`, `REMOTE-USAGE.md`) has been updated to explain the new dynamic runner detection and how to override it manually.
- A CI matrix strategy is proposed to validate the changes across different runners (`uvx`, `npx`, `npm`) and Node.js versions.